### PR TITLE
Added dark Mode

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "launch": "pnpm install && pnpm dev"
+  }
+}

--- a/apps/offline-nextjs/src/app/globals.css
+++ b/apps/offline-nextjs/src/app/globals.css
@@ -32,25 +32,25 @@
 	}
 
 	.dark {
-		--background: 0 0% 3.9%;
-		--foreground: 0 0% 98%;
-		--card: 0 0% 3.9%;
-		--card-foreground: 0 0% 98%;
-		--popover: 0 0% 3.9%;
-		--popover-foreground: 0 0% 98%;
-		--primary: 0 0% 98%;
-		--primary-foreground: 0 0% 9%;
-		--secondary: 0 0% 14.9%;
-		--secondary-foreground: 0 0% 98%;
-		--muted: 0 0% 14.9%;
-		--muted-foreground: 0 0% 63.9%;
-		--accent: 0 0% 14.9%;
-		--accent-foreground: 0 0% 98%;
+		--background: 0 0% 10%;
+		--foreground: 0 0% 90%;
+		--card: 0 0% 15%;
+		--card-foreground: 0 0% 90%;
+		--popover: 0 0% 15%;
+		--popover-foreground: 0 0% 90%;
+		--primary: 0 0% 90%;
+		--primary-foreground: 0 0% 10%;
+		--secondary: 0 0% 20%;
+		--secondary-foreground: 0 0% 90%;
+		--muted: 0 0% 20%;
+		--muted-foreground: 0 0% 60%;
+		--accent: 0 0% 20%;
+		--accent-foreground: 0 0% 90%;
 		--destructive: 0 62.8% 30.6%;
-		--destructive-foreground: 0 0% 98%;
-		--border: 0 0% 14.9%;
-		--input: 0 0% 14.9%;
-		--ring: 0 0% 83.1%;
+		--destructive-foreground: 0 0% 90%;
+		--border: 0 0% 20%;
+		--input: 0 0% 20%;
+		--ring: 0 0% 80%;
 		--chart-1: 220 70% 50%;
 		--chart-2: 160 60% 45%;
 		--chart-3: 30 80% 55%;

--- a/apps/offline-nextjs/src/app/layout.tsx
+++ b/apps/offline-nextjs/src/app/layout.tsx
@@ -1,23 +1,22 @@
+"use client";
+
 import { Button, buttonVariants } from "@/components/ui/button";
 import { excalifont, mathlete, neucha, pacifico } from "@/fonts/fonts";
 import { cn } from "@/lib/utils";
 import { PostHogProviderWrapper } from "@/providers/post-hog";
-import type { Metadata } from "next";
+import { useSettingsStore } from "@/state/settings";
 import Link from "next/link";
 import "./globals.css";
-
-export const metadata: Metadata = {
-	title: "redoit!",
-	description: "Your radically easy-to-use habit tracker",
-};
 
 export default function RootLayout({
 	children,
 }: Readonly<{
 	children: React.ReactNode;
 }>) {
+	const darkModeEnabled = useSettingsStore((state) => state.darkModeEnabled);
+
 	return (
-		<html lang="en">
+		<html lang="en" className={darkModeEnabled ? "dark" : ""}>
 			<PostHogProviderWrapper>
 				<body
 					className={cn(

--- a/apps/offline-nextjs/src/app/settings/page.tsx
+++ b/apps/offline-nextjs/src/app/settings/page.tsx
@@ -11,9 +11,8 @@ import { Switch } from "@/components/ui/switch";
 import { useSettingsStore } from "@/state/settings";
 
 export default function Settings() {
-	const { toggleConfetti, confettiEnabled } = useSettingsStore(
-		(state) => state,
-	);
+	const { toggleConfetti, confettiEnabled, darkModeEnabled, toggleDarkMode } =
+		useSettingsStore((state) => state);
 
 	return (
 		<div className="flex min-h-screen w-full flex-col">
@@ -29,15 +28,6 @@ export default function Settings() {
 						</CardHeader>
 						<CardContent>
 							<form className="flex flex-col gap-4">
-								{/* <div className="flex items-center space-x-2">
-                  <label
-                    htmlFor="countSkippedDays"
-                    className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 mr-auto"
-                  >
-                    Count Skipped Days in Streak
-                  </label>
-                  <Switch id="countSkippedDays" defaultChecked />
-                </div> */}
 								<div className="flex items-center space-x-2">
 									<label
 										htmlFor="showConfetti"
@@ -51,11 +41,21 @@ export default function Settings() {
 										onCheckedChange={toggleConfetti}
 									/>
 								</div>
+								<div className="flex items-center space-x-2">
+									<label
+										htmlFor="darkMode"
+										className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 mr-auto"
+									>
+										Dark Mode
+									</label>
+									<Switch
+										id="darkMode"
+										checked={darkModeEnabled}
+										onCheckedChange={toggleDarkMode}
+									/>
+								</div>
 							</form>
 						</CardContent>
-						{/* <CardFooter className="border-t px-6 py-4">
-              <Button>Save</Button>
-            </CardFooter> */}
 					</Card>
 				</div>
 			</main>

--- a/apps/offline-nextjs/src/state/settings.ts
+++ b/apps/offline-nextjs/src/state/settings.ts
@@ -4,10 +4,12 @@ import { immer } from "zustand/middleware/immer";
 
 type State = {
 	confettiEnabled: boolean;
+	darkModeEnabled: boolean;
 };
 
 type Actions = {
 	toggleConfetti: (value: boolean) => void;
+	toggleDarkMode: (value: boolean) => void;
 };
 
 export const useSettingsStore = create<State & Actions>()(
@@ -15,9 +17,14 @@ export const useSettingsStore = create<State & Actions>()(
 		persist(
 			(set) => ({
 				confettiEnabled: true,
+				darkModeEnabled: false,
 				toggleConfetti: (value) =>
 					set((state) => {
 						state.confettiEnabled = value;
+					}),
+				toggleDarkMode: (value) =>
+					set((state) => {
+						state.darkModeEnabled = value;
 					}),
 			}),
 			{


### PR DESCRIPTION
Add dark mode toggle and improve dark mode styles.

* **Settings Page**: Add a toggle switch for dark mode and use `useSettingsStore` to persist the user's dark mode preference.
* **Layout**: Apply the dark mode class to the `html` element based on the user's preference, use `useSettingsStore` to get the user's dark mode preference, add the "use client" directive, and remove the export of `metadata`.
* **State Management**: Add a state variable for dark mode preference and a function to toggle the dark mode preference in `useSettingsStore`.
* **Global Styles**: Update dark mode styles to improve the appearance of boxes and colors.

